### PR TITLE
fix(--retry-count): remove short option -c

### DIFF
--- a/git_retry.py
+++ b/git_retry.py
@@ -167,7 +167,7 @@ def main(args):
   parser.add_option('-v', '--verbose',
                     action='count', default=0,
                     help="Increase verbosity; can be specified multiple times")
-  parser.add_option('-c', '--retry-count', metavar='COUNT',
+  parser.add_option('--retry-count', metavar='COUNT',
                     type=int, default=GitRetry.DEFAULT_RETRY_COUNT,
                     help="Number of times to retry (default=%default)")
   parser.add_option('-d', '--delay', metavar='SECONDS',


### PR DESCRIPTION
BREAKING CHANGE: `-c` option conflicts with `git -c name=val`.

Git has option `-c` to set config `name=val`. If run `git-retry` with `-c` option:

```
$ git -c "filter.lfs.smudge=" -c "filter.lfs.required=false" checkout master
```

It fails with error:

```
stderr: Usage: git_retry.py [options]
git_retry.py: error: option -c: invalid integer value: 'filter.lfs.smudge='
```